### PR TITLE
fix "unrecognized keyword: maximize"

### DIFF
--- a/kolmafia/scripts/LCSWrapper.ash
+++ b/kolmafia/scripts/LCSWrapper.ash
@@ -1200,11 +1200,6 @@ if(!have_effect($effect[Fireproof Foam Suit]).to_boolean()){
   run_combat(spit);
 }
 
-if(get_property("lcs_august_scepter") == "Offhand Remarkable After Familiar Weight Test"){
-  august_scepter(13);
-}
-
-
 maximize("hot res", false);
 
 while(test_turns(10) > get_property("lcs_turn_threshold_hot_res").to_int()){
@@ -1469,6 +1464,11 @@ if(!have_effect($effect[Mental A-cue-ity]).to_boolean()){
 }
 
 maximize("Spell damage, spell damage percent, switch left-hand man", false);
+
+
+if(get_property("lcs_august_scepter") == "Offhand Remarkable After Familiar Weight Test"){
+  august_scepter(13);
+}
 
 if(pulls_remaining() > 0 && !alice_army_snack($effect[Pisces in the Skyces])){
 

--- a/kolmafia/scripts/LCSWrapperResources.ash
+++ b/kolmafia/scripts/LCSWrapperResources.ash
@@ -608,9 +608,9 @@ string [int] hot_res_effects = {
     "Leash of Linguini",
     "Empathy",
     "Amazing",
-    "Feeling Peaceful",
-    "Hot-headed",
 	"Rainbow Vaccine",
+    "Hot-headed",
+	"Feeling Peaceful",
     "END",
 };
 


### PR DESCRIPTION
line 1641 contained:

maximize('maximize -combat, 0.04 familiar weight 75 max, switch disgeist, switch left-hand man, switch disembodied hand, -tie', false);

now contains

maximize('-combat, 0.04 familiar weight 75 max, switch disgeist, switch left-hand man, switch disembodied hand, -tie', false);