### PR TITLE
LCSWrapper.ash Left-Hand Man Declubbify

### DIFF
--- a/kolmafia/scripts/LCSWrapper.ash
+++ b/kolmafia/scripts/LCSWrapper.ash
@@ -1940,6 +1940,15 @@ void donate_body_to_science(){
   visit_url("storage.php");
   cli_execute("hagnk all");
 
+  //This is just to prevent self-clubbing, primarily with the August Scepter, but also otherwise to prevent random weapons/off-hands from potentially getting lost in your terrarium
+  if(have_familiar($familiar[Left-hand Man])){
+  use_familiar($familiar[Left-hand Man]);
+  cli_execute("unequip familiar");
+
+  if(have_familiar($familiar[Disembodied Hand])){
+  use_familiar($familiar[Disembodied Hand]);
+  cli_execute("unequip familiar");
+
   refresh();
   if(available_amount($item[Beach Comb]).to_boolean()){
     cli_execute(`try; combo {11 - get_property("_freeBeachWalksUsed").to_int()}`);


### PR DESCRIPTION
Just after emptying Hangk's, added a couple lines to unequip user's Disembodied Hand or Left-Hand Man, as well as an in-line comment to explain that it's mostly just to prevent self-clubbing with August Scepter